### PR TITLE
Fixed too many legendaries

### DIFF
--- a/src/main/kotlin/service/store/StoreService.kt
+++ b/src/main/kotlin/service/store/StoreService.kt
@@ -25,7 +25,7 @@ const val RedisKeyBoosterpacks = "boosterpacks"
 const val RedisKeyBoosterpackIds = "boosterpack_ids"
 val LegendaryPokemon = intArrayOf(144, 145, 146, 150, 151, 243, 244, 245, 249, 250, 251, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649)
 val LegendaryPokemonXPMultiplier = BigDecimal(10)
-const val LegendaryPokemonInBoosterPack = 6 //Once every LegendaryPokemonInBoosterPack times there is a legendary pokemon in a booster pack. Please note that this doesn't mean that you'll also draw this pokemon.
+const val LegendaryPokemonInBoosterPack = 500 //Once every LegendaryPokemonInBoosterPack times there is a legendary pokemon in a booster pack. Please note that this doesn't mean that you'll also draw this pokemon.
 
 class StoreService {
     private val gson = Gson()

--- a/src/main/kotlin/service/store/StoreService.kt
+++ b/src/main/kotlin/service/store/StoreService.kt
@@ -90,10 +90,9 @@ class StoreService {
         val sortedPokemons = pokemons.sortedBy { it.xp }.asReversed()
 
         val possiblePokemons = arrayListOf<ThinPokemon>()
-		if(Random.nextInt(0, LegendaryPokemonInBoosterPack) == 0) possiblePokemons.add(PokeApi().getPokemon(LegendaryPokemon.random()));
         sortedPokemons.forEachIndexed { index, pokemon -> repeat(index + 1) { possiblePokemons.add(pokemon) } }
 
-        val drawnPokemons = possiblePokemons.shuffled().take(BoosterpackSize)
+        val drawnPokemons = possiblePokemons.shuffled().map { pkmn -> if (Random.nextInt(0, LegendaryPokemonInBoosterPack) == 0) PokeApi().getPokemon(LegendaryPokemon.random()) else pkmn }.take(BoosterpackSize)
         drawnPokemons.forEach {
             val xp = (boosterpackPrice.multiply((getReasonablyNormallyDistributedDouble() + 1).toBigDecimal()).divide((SecondsInFiveMinutes * BoosterpackSize).toBigDecimal(), CEILING)).setScale(0, CEILING)
 
@@ -103,7 +102,7 @@ class StoreService {
                 it.xp = xp
             }
 
-            if (LegendaryPokemon.contains(it.id)) {  // Legendary pokemon are 10 times as powerful as normal pokemon :)
+            if (LegendaryPokemon.contains(it.id)) {  // Legendary pokemon are LegendaryPokemonXPMultiplier times as powerful as normal pokemon :)
                 it.xp *= LegendaryPokemonXPMultiplier
             }
         }


### PR DESCRIPTION
The amount of legendaries previously depended on the size of the pack. Now I made it that once every 500 pokemon a legendary will show up.

Closes #73